### PR TITLE
Change abs parameter to int|float

### DIFF
--- a/reference/math/functions/abs.xml
+++ b/reference/math/functions/abs.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
    <methodsynopsis>
     <type class="union"><type>int</type><type>float</type></type><methodname>abs</methodname>
-    <methodparam><type>mixed</type><parameter>number</parameter></methodparam>
+    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>number</parameter></methodparam>
    </methodsynopsis>
   <para>
    Returns the absolute value of <parameter>number</parameter>. 


### PR DESCRIPTION
The behavior changed in PHP 8. Passing "foo" always throws a TypeError, passing a number as string throws a TypeError if `strict_types=1`.